### PR TITLE
Correct namespace for FileUtilz constant

### DIFF
--- a/lib/tasks/reviews_extension_tasks.rake
+++ b/lib/tasks/reviews_extension_tasks.rake
@@ -11,7 +11,7 @@ namespace :spree_reviews do
       source = File.join(File.dirname(__FILE__), '..', '..', 'db')
       destination = File.join(Rails.root, 'db')
       puts "INFO: Mirroring assets from #{source} to #{destination}"
-      Spree::FileUtilz.mirror_files(source, destination)
+      Spree::Core::FileUtilz.mirror_files(source, destination)
     end
 
     desc "Copies all assets (NOTE: This will be obsolete with Rails 3.1)"
@@ -19,7 +19,7 @@ namespace :spree_reviews do
       source = File.join(File.dirname(__FILE__), '..', '..', 'public')
       destination = File.join(Rails.root, 'public')
       puts "INFO: Mirroring assets from #{source} to #{destination}"
-      Spree::FileUtilz.mirror_files(source, destination)
+      Spree::Core::FileUtilz.mirror_files(source, destination)
     end
   end
 end


### PR DESCRIPTION
Corrects namespace to match change spree/spree@1a2fbb40d1927668f42868984c6f03c6fa35a5f3
