### PR TITLE
Use jquery.ratings to display stars and not just radio buttons

### DIFF
--- a/app/assets/javascripts/store/spree_reviews.js
+++ b/app/assets/javascripts/store/spree_reviews.js
@@ -1,0 +1,2 @@
+//= require jquery.rating
+$(function(){ $('.stars').rating({required:true}); });

--- a/app/views/spree/shared/_rating.html.erb
+++ b/app/views/spree/shared/_rating.html.erb
@@ -3,7 +3,7 @@
 <div class="ratings">
   <p><%= t('average_customer_rating') %>: </p>
   <p>
-    <span title="<%= txt_stars(stars) %>">
+    <span class="stars" title="<%= txt_stars(stars) %>">
       <%= render :partial => "spree/reviews/stars", :locals => {:stars => stars} %>
     </span>
   </p>

--- a/app/views/spree/shared/_review.html.erb
+++ b/app/views/spree/shared/_review.html.erb
@@ -1,5 +1,5 @@
 <div class="review" itemprop="reviews" itemscope itemtype="http://schema.org/Review">
-  <span title="<%= txt_stars(review.rating) %>">
+  <span class="stars" title="<%= txt_stars(review.rating) %>">
     <%= render :partial => "spree/reviews/stars", :locals => {:stars => review.rating} %>
   </span>
   <meta itemprop="reviewRating" content="<%= review.rating %>" />

--- a/app/views/spree/shared/_shortrating.html.erb
+++ b/app/views/spree/shared/_shortrating.html.erb
@@ -1,6 +1,6 @@
 <% stars = product.stars %>
 <% reviews_count = product.reviews_count %>
-<span style="float:left;" title="<%= txt_stars(stars) %>">
+<span class="stars" style="float:left;" title="<%= txt_stars(stars) %>">
   <%= render :partial => "spree/reviews/stars", :locals => {:stars => stars} %>
 </span>
 <span style="float:right;">


### PR DESCRIPTION
The call to initialize jquery.ratings was pulled out by someone and the ratings was just show radio buttons and not the stars.
