### PR TITLE
Fixed `script/rails` to Enable Rails Generators

### DIFF
--- a/script/rails
+++ b/script/rails
@@ -1,0 +1,5 @@
+# This command will automatically be run when you run "rails" with Rails 3 gems installed from the root of your application.
+
+APP_PATH = File.expand_path('../../config/application',  __FILE__)
+require File.expand_path('../../config/boot',  __FILE__)
+require 'rails/commands'


### PR DESCRIPTION
Very simple, 

Including the correct version of the rails script file to enable the Rails generators for spree-1-0 and Rails 3.1+. The version used was suggested by Ryan Bigg (radar): https://github.com/spree/spree/blob/1-0-stable/cmd/lib/spree_cmd/templates/extension/script/rails.tt

Cheers
