### PR TITLE
Fixed `script/rails` to Enable Rails Generators for 3.1+

### DIFF
--- a/script/rails
+++ b/script/rails
@@ -1,0 +1,5 @@
+#!/usr/bin/env ruby
+# This command will automatically be run when you run "rails" with Rails 3 gems installed from the root of your application.
+
+ENGINE_PATH = File.expand_path('../..',  __FILE__)
+load File.expand_path('../../spec/dummy/script/rails',  __FILE__)


### PR DESCRIPTION
Redoing my previous false alarm pull request. 

Including the correct version this time around.
