### PR TITLE
Fix for Rails security update. Need to make those attributes accessible

### DIFF
--- a/app/models/spree/product_decorator.rb
+++ b/app/models/spree/product_decorator.rb
@@ -2,6 +2,8 @@
 Spree::Product.class_eval do
   has_many :reviews
 
+  attr_accessible :avg_rating, :reviews_count
+
   def stars
     avg_rating.round
   end


### PR DESCRIPTION
Both "avg_rating" and "reviews_count" where not accessible, therefor preventing a review to be approved. 
