### PR TITLE
Removed unused override

### DIFF
--- a/app/overrides/add_jquery_rating.rb
+++ b/app/overrides/add_jquery_rating.rb
@@ -1,8 +1,0 @@
-Deface::Override.new(:virtual_path => "spree/shared/_footer",
-                     :name => "converted_footer_right_920701005",
-                     :insert_after => "[data-hook='footer_right'], #footer_right[data-hook]",
-                     :text => "
-    <%= javascript_include_tag(\"jquery.rating.js\") %>
-    <%= javascript_tag(\"$(document).ready(function(){$('.stars').rating({required:true});});\") %>
-    ",
-                     :disabled => false)


### PR DESCRIPTION
This override is not used. 
-  The template it overrides does not exist in 1-1-stable
-  The javascript file is included in the generator by appending it to the application.js
-  The javascript call does not work since there is no item with class ".stars"

Plugin seems to work without this so I decided to remove it. 
