### PR TITLE
Updated stylesheet to use asset_path for images

### DIFF
--- a/app/assets/stylesheets/store/spree_reviews.css.erb
+++ b/app/assets/stylesheets/store/spree_reviews.css.erb
@@ -62,11 +62,11 @@ div.rating-cancel, div.star-rating {
 }
 
 div.rating-cancel, div.rating-cancel a {
-  background: transparent url('/assets/store/reviews/delete.gif') no-repeat scroll 0 -16px;
+  background: transparent url("<%= asset_path('store/reviews/delete.gif') %>") no-repeat scroll 0 -16px;
 }
 
 div.star-rating, div.star-rating a {
-  background: url('/assets/store/reviews/star.gif') no-repeat 0 0px;
+  background: url("<%= asset_path('store/reviews/star.gif') %>") no-repeat 0 0px;
 }
 
 div.rating-cancel a, div.star-rating a {


### PR DESCRIPTION
With precompiled assets, review star and delete images were breaking due to hard-linking to /assets/store/images/reviews/star.gif, etc...

Tested and working on production.
