### PR TITLE
remove dead admin_configuration_menu override

### DIFF
--- a/app/overrides/add_reviews_to_admin_configuration_menu.rb
+++ b/app/overrides/add_reviews_to_admin_configuration_menu.rb
@@ -1,5 +1,0 @@
-Deface::Override.new(:virtual_path => "spree/admin/configurations/index",
-                     :name => "converted_admin_configurations_menu_286465532",
-                     :insert_bottom => "[data-hook='admin_configurations_menu'], #admin_configurations_menu[data-hook]",
-                     :text => "<%= configurations_menu_item(t('spree_reviews.review_settings'), edit_admin_review_settings_path, Spree.t('spree_reviews.manage_review_settings')) %>",
-                     :disabled => false)


### PR DESCRIPTION
spree/admin/configurations/index no longer exists as of spree 1.3. It was removed in spree/spree@6efd86d24f3094966afa14ee07b87d715eadff2a

If this could please be applied to master, 2-0-stable, and 1-3-stable.
