### PR TITLE
1-3-stable: remove add_reviews_to_admin_configuration_menu

### DIFF
--- a/app/overrides/add_reviews_to_admin_configuration_menu.rb
+++ b/app/overrides/add_reviews_to_admin_configuration_menu.rb
@@ -1,5 +1,0 @@
-Deface::Override.new(:virtual_path => "spree/admin/configurations/index",
-                     :name => "converted_admin_configurations_menu_286465532",
-                     :insert_bottom => "[data-hook='admin_configurations_menu'], #admin_configurations_menu[data-hook]",
-                     :text => "<%= configurations_menu_item(t('spree_reviews.review_settings'), admin_review_settings_path, t('spree_reviews.manage_review_settings')) %>",
-                     :disabled => false)


### PR DESCRIPTION
spree/admin/configurations/index no longer exists as of spree 1.3. It was removed in spree/spree@6efd86d

Rebase of #62 against 1-3-stable.
