### PR TITLE
Navigating to a page with ratings within an application using Turbolinks shows just the radio buttons.

### DIFF
--- a/app/assets/javascripts/admin/spree_reviews.js
+++ b/app/assets/javascripts/admin/spree_reviews.js
@@ -1,0 +1,4 @@
+// Navigating to a page with ratings via TurboLinks shows the radio buttons
+document.addEventListener("page:load", function(){
+    $('input[type=radio].star').rating();
+});

--- a/app/assets/javascripts/store/spree_reviews.js
+++ b/app/assets/javascripts/store/spree_reviews.js
@@ -1,0 +1,4 @@
+// Navigating to a page with ratings via TurboLinks shows the radio buttons
+document.addEventListener("page:load", function(){
+    $('input[type=radio].star').rating();
+});


### PR DESCRIPTION
This issue occurs even with the jquery.turbolinks plugin to rerun all the document ready events. For a new rails app (or any older app using turbolinks) this issue shows up because the rating is not getting reinitialized on the radio buttons.
