### PR TITLE
feedback_reviews model didn't have any attr_accessible

### DIFF
--- a/app/models/spree/feedback_review.rb
+++ b/app/models/spree/feedback_review.rb
@@ -9,4 +9,5 @@ class Spree::FeedbackReview < ActiveRecord::Base
 
   scope :localized, lambda { |lc| where('spree_reviews.locale = ?', lc) }
 
+  attr_accessible :user_id, :rating
 end


### PR DESCRIPTION
I was getting an error on creating a feedback rating because mass assignment wasn't setup.
