### PR TITLE
[master] Try to save us from db locking in spec runs.

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,3 @@
-# Configure Rails Environment
 ENV["RAILS_ENV"] = "test"
 require 'simplecov' if ENV['COVERAGE']
 require File.expand_path("../dummy/config/environment.rb",  __FILE__)
@@ -18,7 +17,7 @@ require 'spree/testing_support/controller_requests'
 require 'spree/testing_support/authorization_helpers'
 require 'spree/testing_support/url_helpers'
 
-Dir[File.join(File.dirname(__FILE__), "factories/*.rb")].each {|f| require f }
+FactoryGirl.find_definitions
 
 RSpec.configure do |config|
   config.include Spree::TestingSupport::ControllerRequests
@@ -26,16 +25,13 @@ RSpec.configure do |config|
   config.include Spree::TestingSupport::UrlHelpers
   config.extend Spree::TestingSupport::AuthorizationHelpers::Request, :type => :feature
   config.use_transactional_fixtures = false
-  config.before(:each) do
-    if example.metadata[:js]
-      DatabaseCleaner.strategy = :truncation
-    else
-      DatabaseCleaner.strategy = :transaction
-    end
-    DatabaseCleaner.start
+
+  config.before(:suite) do
+    DatabaseCleaner.strategy = :transaction
+    DatabaseCleaner.clean_with(:truncation)
   end
 
-  config.after(:each) do
+  config.around do
     DatabaseCleaner.clean
   end
 

--- a/spree_reviews.gemspec
+++ b/spree_reviews.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency 'ffaker'
   s.add_development_dependency 'capybara', '~> 2.1'
-  s.add_development_dependency 'database_cleaner', '1.0.1'
+  s.add_development_dependency 'database_cleaner', '1.2.0'
   s.add_development_dependency 'poltergeist', '1.4.1'
   s.add_development_dependency 'rspec-rails', '~> 2.12'
   s.add_development_dependency 'factory_girl_rails', '~> 4.2'


### PR DESCRIPTION
- Bumped database cleaner to 1.2.0
- Change spec strategy for how it runs.

This due to that I got random failed spec runs due to random table locking SQLite3::BusyException: database is locked.
