### PR TITLE
Fix admin tab translation scope

### DIFF
--- a/config/locales/de-CH.yml
+++ b/config/locales/de-CH.yml
@@ -38,7 +38,9 @@ de-CH:
     out_of_5: "von 5"
     rating: Bewertung
     reviews: Rezensionen
-    review_management: Rezensionen
+    admin:
+      tab:
+        review_management: Rezensionen
     review_successfully_submitted: "Ihre Rezension wurde erfolgreich übertragen. Vielen Dank!"
     spree_reviews:
       feedback_rating: Feedback für Rezensionen erlauben

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -38,7 +38,9 @@ de:
     out_of_5: "von 5"
     rating: Bewertung
     reviews: Rezensionen
-    review_management: Rezensionen
+    admin:
+      tab:
+        review_management: Rezensionen
     review_successfully_submitted: Ihre Rezension wurde erfolgreich übertragen. Vielen Dank!
     spree_reviews:
       feedback_rating: Feedback für Rezensionen erlauben

--- a/config/locales/en-GB.yml
+++ b/config/locales/en-GB.yml
@@ -37,7 +37,9 @@ en-GB:
     out_of_5: "out of 5"
     rating: rating
     reviews: Reviews
-    review_management: Reviews
+    admin:
+      tab:
+        review_management: Reviews
     review_successfully_submitted: Review was successfully submitted
     spree_reviews:
       feedback_rating: Rate feedback

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -36,7 +36,9 @@ en:
     out_of_5: "out of 5"
     rating: rating
     reviews: Reviews
-    review_management: Reviews
+    admin:
+      tab:
+        review_management: Reviews
     review_successfully_submitted: Review was successfully submitted
     spree_reviews:
       feedback_rating: Rate feedback

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -37,7 +37,9 @@ es:
     out_of_5: "de 5"
     rating: puntuación
     reviews: Valoraciones
-    review_management: "Valoraciones"
+    admin:
+      tab:
+        review_management: "Valoraciones"
     review_successfully_submitted: "La valoración se ha enviado correctamente"
     spree_reviews:
       feedback_rating: "Puntuación en el feedback"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -37,7 +37,9 @@ fr:
     out_of_5: "sur 5"
     rating: note
     reviews: Commentaires
-    review_management: Commentaires
+    admin:
+      tab:
+        review_management: Commentaires
     review_successfully_submitted: Votre commentaire a été envoyé avec succès
     spree_reviews:
       feedback_rating: Note de réaction

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -39,7 +39,9 @@ pl:
     out_of_5: "z 5"
     rating: Ocena
     reviews: Opinie
-    review_management: Opinie
+    admin:
+      tab:
+        review_management: Opinie
     review_successfully_submitted: Opinia została dodana
     spree_reviews:
       feedback_rating: Oceń komentarz

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -37,7 +37,9 @@ pt-BR:
     out_of_5: "fora de 5"
     rating: 'classificação'
     reviews: 'Avaliações'
-    review_management: 'Avaliações'
+    admin:
+      tab:
+        review_management: 'Avaliações'
     review_successfully_submitted: 'Avaliação enviada com sucesso'
     spree_reviews:
       feedback_rating: 'Classifique um parecer'

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -37,7 +37,9 @@ pt:
     out_of_5: "de 5"
     rating: pontuação
     reviews: Avaliações
-    review_management: Gestão Avaliações
+    admin:
+      tab:
+        review_management: Gestão Avaliações
     review_successfully_submitted: A avaliação foi enviada com sucesso
     submission_guidelines: Diretrizes para enviar boas avaliações
     spree_reviews:

--- a/config/locales/ro.yml
+++ b/config/locales/ro.yml
@@ -41,7 +41,9 @@ ro:
     out_of_5: "din 5"
     rating: evaluare
     reviews: Recenzii
-    review_management: Recenzii
+    admin:
+      tab:
+        review_management: Recenzii
     review_successfully_submitted: Recenzia a fost trimisă cu succes
     spree_reviews:
       feedback_rating: Evaluează feedback

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -20,7 +20,9 @@ ru:
   spree:
     reviews: Отзывы
     write_your_own_review: Оставьте свой отзыв
-    review_management: Управление отзывами
+    admin:
+      tab:
+        review_management: Управление отзывами
     back_reviews: Назад к отзывам
     info_approve_review: Отзыв одобрен
     error_approve_review: Ошибка при одобрении отзыва

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -36,7 +36,9 @@ sv:
     no_reviews_available: "Inga recensioner har ännu skrivits för den här produkten."
     out_of_5: "ut av 5"
     rating: betyg
-    review_management: "Hantera recensioner"
+    admin:
+      tab:
+        review_management: "Hantera recensioner"
     review_successfully_submitted: "Recension har skapats"
     reviews: Recensioner
     spree_reviews:

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -37,7 +37,9 @@ tr:
     out_of_5: "5 üzerinden"
     rating: değerlendirme
     reviews: Yorumlar
-    review_management: Yorumlar
+    admin:
+      tab:
+        review_management: Yorumlar
     review_successfully_submitted: Yorumunuz başarıyla iletildi
     spree_reviews:
       feedback_rating: Geribildirimi değerlendir


### PR DESCRIPTION
Fix scope for admin tab translation. Spree backend navigation_helper.rb defines admin > tab as default scope for translations.
