### PR TITLE
fix font-awesome icon name

### DIFF
--- a/app/views/spree/admin/reviews/index.html.erb
+++ b/app/views/spree/admin/reviews/index.html.erb
@@ -92,7 +92,7 @@
 					<%= l review.created_at, :format => :short %>
 				</td>
 				<td class="actions">
-					<%= link_to_with_icon 'icon-check', Spree.t('approve'), approve_admin_review_url(review), :no_text => true, class: 'approve' unless review.approved %>
+					<%= link_to_with_icon 'check', Spree.t('approve'), approve_admin_review_url(review), :no_text => true, class: 'approve' unless review.approved %>
 					&nbsp;
 					<%= link_to_edit review, :no_text => true, :class => 'edit' %>
 					&nbsp;


### PR DESCRIPTION
The approve button wasn't using a valid font-awesome icon class, resulting in an empty circle with no icon.  This adds back the checkmark.
