### PR TITLE
remove hidden userid field and set the user id from the current_user

### DIFF
--- a/app/controllers/spree/feedback_reviews_controller.rb
+++ b/app/controllers/spree/feedback_reviews_controller.rb
@@ -8,6 +8,7 @@ class Spree::FeedbackReviewsController < Spree::StoreController
 
     if @review.present?
       @feedback_review = @review.feedback_reviews.new(feedback_review_params)
+      @feedback_review.user = spree_current_user
       @feedback_review.locale = I18n.locale.to_s if Spree::Reviews::Config[:track_locale]
       authorize! :create, @feedback_review
       @feedback_review.save
@@ -20,7 +21,7 @@ class Spree::FeedbackReviewsController < Spree::StoreController
 
   end
 
-  protected 
+  protected
     def load_review
       @review ||= Spree::Review.find_by_id!(params[:review_id])
     end

--- a/app/views/spree/feedback_reviews/_form.html.erb
+++ b/app/views/spree/feedback_reviews/_form.html.erb
@@ -9,7 +9,6 @@
   <%= radio_button_tag "feedback_review[rating]",
                        Spree.t('star', :count => i), false, :class => "star" %>
 <% end %>
-<%= hidden_field_tag "feedback_review[user_id]", spree_current_user.try(:id) %>
 <button class="feedback-review"><span><%= Spree.t(:say_yes) %></span></button>
 <% end %>
 

--- a/spec/controllers/feedback_reviews_controller_spec.rb
+++ b/spec/controllers/feedback_reviews_controller_spec.rb
@@ -30,6 +30,7 @@ describe Spree::FeedbackReviewsController do
           feedback_review.comment.should eq(comment)
           feedback_review.review.should eq(review)
           feedback_review.rating.should eq(rating)
+          feedback_review.user.should eq(user)
 
         end
       end


### PR DESCRIPTION
Alternative to PR #85.  the user_id should be sent in the form.  This would allow someone to post feedback posing as someone else.  Instead, set the user from the current user in the session
