### PR TITLE
Remove unnessisary deface override

### DIFF
--- a/app/overrides/fix_highlighting_of_products_tab.rb
+++ b/app/overrides/fix_highlighting_of_products_tab.rb
@@ -1,5 +1,0 @@
-Deface::Override.new(:virtual_path => "spree/admin/shared/_tabs",
-                    :name => "reviews_admin_tab_root",
-                    :replace_contents => "erb[loud]:contains('tab :products')",
-                    :text => "tab :products, :option_types, :properties, :prototypes, :variants, :product_properties, :taxons, :reviews, :icon => 'icon-th-large'",
-                    :original => '0abc74602592114216d5a53bc095823ec6759895')


### PR DESCRIPTION
Whatever purpose this may have served in the past, it no longer seems necessary to highlight the product tab in Spree 2-1-stable.
