### PR TITLE
Translate submitted_on correctly

### DIFF
--- a/app/views/spree/shared/_review.html.erb
+++ b/app/views/spree/shared/_review.html.erb
@@ -4,7 +4,7 @@
   </span>
   <span itemprop="name"><%= review.title %></span>
   <br/>
-  <span class="attribution"><%= t('submitted_on') %> <strong><%= l review.created_at.to_date %></strong></span>
+  <span class="attribution"><%= Spree.t(:submitted_on) %> <strong><%= l review.created_at.to_date %></strong></span>
   <meta itemprop="datePublished" content="<%= review.created_at.to_date.to_s %>" />
 
   <meta itemprop="reviewRating" content="<%= review.rating %>" />


### PR DESCRIPTION
Same as #122, but for `2-3-stable`
