### PR TITLE
Remove 'noindex' from rel attr

### DIFF
--- a/app/views/spree/shared/_reviews.html.erb
+++ b/app/views/spree/shared/_reviews.html.erb
@@ -10,6 +10,6 @@
   <% end %>
   <% if !Spree::Reviews::Config[:require_login] || spree_current_user %>
     <%= link_to Spree.t('write_your_own_review'), new_product_review_path(@product), :class => "button",
-                :rel => "nofollow,noindex" %>
+                :rel => 'nofollow' %>
   <% end %>
 </div>


### PR DESCRIPTION
`noindex` is not a valid [link type](https://html.spec.whatwg.org/multipage/semantics.html#linkTypes) and makes the page's HTML invalid.
