### PR TITLE
admin feedback reviews table data not in correct order

### DIFF
--- a/app/views/spree/admin/feedback_reviews/index.html.erb
+++ b/app/views/spree/admin/feedback_reviews/index.html.erb
@@ -27,9 +27,9 @@
 		<tbody>
 		<%- @collection.each do |feedback| -%>
 			<tr id="<%= dom_id(feedback) %>">
-			  <td><%= l feedback.created_at %></td>
 			  <td><%= feedback.user.try(:login) || Spree.t(:anonymous) %></td>
 			  <td><%= feedback.rating %></td>
+			  <td><%= l feedback.created_at %></td>
 			  <td class="actions">
 				  <%= link_to_delete feedback, :no_text => true  %>
 			  </td>


### PR DESCRIPTION
table headers and table data not in  same order On admin_feedback_reviews's index page . so that   data miss matchining  with table headers . 
