### PR TITLE
avg_rating and reviews_count fields are available on Spree API side

### DIFF
--- a/app/controllers/spree/products_controller_decorator.rb
+++ b/app/controllers/spree/products_controller_decorator.rb
@@ -1,5 +1,10 @@
 Spree::ProductsController.class_eval do
   helper Spree::ReviewsHelper
 
-  [:avg_rating, :reviews_count].each { |attrib| Spree::PermittedAttributes.product_attributes << attrib }
+  reviews_fields = [:avg_rating, :reviews_count]
+  reviews_fields.each { |attrib| Spree::PermittedAttributes.product_attributes << attrib }
+
+  Spree::Api::ApiHelpers.class_eval do
+    reviews_fields.each { |attrib| class_variable_set(:@@product_attributes, class_variable_get(:@@product_attributes).push(attrib)) }
+  end
 end

--- a/spec/controllers/products_controller_spec.rb
+++ b/spec/controllers/products_controller_spec.rb
@@ -1,7 +1,13 @@
 RSpec.describe Spree::ProductsController, type: :controller do
-  [:avg_rating, :reviews_count].each do |attrib|
+  reviews_fields = [:avg_rating, :reviews_count]
+  reviews_fields.each do |attrib|
     it "adds #{attrib} to the set of allowed attributes" do
       expect(controller.permitted_product_attributes).to include(attrib)
+    end
+  end
+  reviews_fields.each do |attrib|
+    it "adds #{attrib} to the set of available attributes from Spree API" do
+      expect(Spree::Api::ApiHelpers.product_attributes).to include(attrib)
     end
   end
 end


### PR DESCRIPTION
This modification allow to get :avg_rating and :reviews_count fields on Spree API side.
Example of response GET /api/products:
{...,"products":[{"id":1,...,"avg_rating":"1.66667","reviews_count":3,...}]}