### PR TITLE
fix message which is shown when there is no review in the system

### DIFF
--- a/app/views/spree/admin/reviews/index.html.erb
+++ b/app/views/spree/admin/reviews/index.html.erb
@@ -78,7 +78,7 @@
 	</table>
 <% else %>
 	<div class="alert alert-info no-objects-found">
-		<%= Spree.t(:no_resource_found, resource: I18n.t(:other, scope: 'activerecord.models.spree/review')) %>
+		<%= Spree.t(:no_resource_found, resource: Spree.t(:reviews)) %>
 	</div>
 <% end %>
 


### PR DESCRIPTION
The message currently shown on `admin/reviews` page when there is no review present in db is **No %{count} reviews found** which I guess should be **No Reviews found**. 