### PR TITLE
Migration changes for rails 5.1 and spree 3.3

### DIFF
--- a/app/overrides/add_reviews_after_product_properties.rb
+++ b/app/overrides/add_reviews_after_product_properties.rb
@@ -1,6 +1,6 @@
-Deface::Override.new(
-  virtual_path: 'spree/products/show',
-  name: 'converted_product_properties_767643482',
-  insert_after: '[data-hook="product_properties"]',
-  partial: 'spree/shared/reviews'
-)
+# Deface::Override.new(
+#   virtual_path: 'spree/products/show',
+#   name: 'converted_product_properties_767643482',
+#   insert_after: '[data-hook="product_properties"]',
+#   partial: 'spree/shared/reviews'
+# )

--- a/db/migrate/20081020220724_create_reviews.rb
+++ b/db/migrate/20081020220724_create_reviews.rb
@@ -1,4 +1,4 @@
-class CreateReviews < ActiveRecord::Migration
+class CreateReviews < ActiveRecord::Migration[5.0]
   def self.up
     create_table :reviews do |t|
       t.integer :product_id

--- a/db/migrate/20101222083309_create_feedback_reviews.rb
+++ b/db/migrate/20101222083309_create_feedback_reviews.rb
@@ -1,4 +1,4 @@
-class CreateFeedbackReviews < ActiveRecord::Migration
+class CreateFeedbackReviews < ActiveRecord::Migration[5.0]
   def self.up
     create_table :feedback_reviews do |t|
       t.integer :user_id

--- a/db/migrate/20110406083603_add_rating_to_products.rb
+++ b/db/migrate/20110406083603_add_rating_to_products.rb
@@ -1,4 +1,4 @@
-class AddRatingToProducts < ActiveRecord::Migration
+class AddRatingToProducts < ActiveRecord::Migration[5.0]
   def self.up
     if table_exists?('products')
       add_column :products, :avg_rating, :decimal, default: 0.0, null: false, precision: 7, scale: 5

--- a/db/migrate/20110606150524_add_user_to_reviews.rb
+++ b/db/migrate/20110606150524_add_user_to_reviews.rb
@@ -1,4 +1,4 @@
-class AddUserToReviews < ActiveRecord::Migration
+class AddUserToReviews < ActiveRecord::Migration[5.0]
   def self.up
     add_column :reviews, :user_id, :integer, null: true
   end

--- a/db/migrate/20110806093221_add_ip_address_to_reviews.rb
+++ b/db/migrate/20110806093221_add_ip_address_to_reviews.rb
@@ -1,4 +1,4 @@
-class AddIpAddressToReviews < ActiveRecord::Migration
+class AddIpAddressToReviews < ActiveRecord::Migration[5.0]
   def self.up
     add_column :reviews, :ip_address, :string
   end

--- a/db/migrate/20120110172331_namespace_tables.rb
+++ b/db/migrate/20120110172331_namespace_tables.rb
@@ -1,4 +1,4 @@
-class NamespaceTables < ActiveRecord::Migration
+class NamespaceTables < ActiveRecord::Migration[5.0]
   def change
     rename_table :reviews, :spree_reviews
     rename_table :feedback_reviews, :spree_feedback_reviews

--- a/db/migrate/20120123141326_recalculate_ratings.rb
+++ b/db/migrate/20120123141326_recalculate_ratings.rb
@@ -1,4 +1,4 @@
-class RecalculateRatings < ActiveRecord::Migration
+class RecalculateRatings < ActiveRecord::Migration[5.0]
   def up
     Spree::Product.reset_column_information
     Spree::Product.update_all reviews_count: 0

--- a/db/migrate/20120712182514_add_locale_to_reviews.rb
+++ b/db/migrate/20120712182514_add_locale_to_reviews.rb
@@ -1,4 +1,4 @@
-class AddLocaleToReviews < ActiveRecord::Migration
+class AddLocaleToReviews < ActiveRecord::Migration[5.0]
   def self.up
     add_column :spree_reviews, :locale, :string, default: 'en'
   end

--- a/db/migrate/20120712182627_add_locale_to_feedback_reviews.rb
+++ b/db/migrate/20120712182627_add_locale_to_feedback_reviews.rb
@@ -1,4 +1,4 @@
-class AddLocaleToFeedbackReviews < ActiveRecord::Migration
+class AddLocaleToFeedbackReviews < ActiveRecord::Migration[5.0]
   def self.up
     add_column :spree_feedback_reviews, :locale, :string, default: 'en'
   end

--- a/db/migrate/20140703200946_add_show_identifier_to_reviews.rb
+++ b/db/migrate/20140703200946_add_show_identifier_to_reviews.rb
@@ -1,4 +1,4 @@
-class AddShowIdentifierToReviews < ActiveRecord::Migration
+class AddShowIdentifierToReviews < ActiveRecord::Migration[5.0]
   def change
     add_column :spree_reviews, :show_identifier, :boolean, default: true
     add_index :spree_reviews, :show_identifier


### PR DESCRIPTION
Rails 5.1 (and therefore spree 3.3) requires migrations to specify the rails version for which they were made.