### PR TITLE
add optional: true to belongs_to :user association to work with Rails 5+

### DIFF
--- a/app/models/spree/review.rb
+++ b/app/models/spree/review.rb
@@ -1,6 +1,6 @@
 class Spree::Review < ActiveRecord::Base
   belongs_to :product, touch: true
-  belongs_to :user, class_name: Spree.user_class.to_s
+  belongs_to :user, class_name: Spree.user_class.to_s, optional: true
   has_many   :feedback_reviews
 
   after_save :recalculate_product_rating, if: :approved?


### PR DESCRIPTION
Rails 5 changed belongs_to associations to be required to save. This extension has an option to allow anonymous reviews, but this does not work on Rails 5 applications without the belongs_to being optional.

Adding the optional: true allows creating anonymous reviews - tested on Spree 3.7 with Rails 5.2.