### PR TITLE
Update spree_reviews.gemspec

### DIFF
--- a/spree_reviews.gemspec
+++ b/spree_reviews.gemspec
@@ -24,7 +24,6 @@ Gem::Specification.new do |s|
   s.add_dependency 'deface', '~> 1.0'
   s.add_dependency 'spree_api', spree_version
   s.add_dependency 'spree_backend', spree_version
-  s.add_dependency 'spree_frontend', spree_version
   s.add_dependency 'spree_core', spree_version
   s.add_dependency 'spree_extension'
 


### PR DESCRIPTION
Resolve [issue#198](https://github.com/spree-contrib/spree_reviews/issues/198):

- Remove `spree_frontend` gem dependency.